### PR TITLE
Implement publication status API endpoints for issue #106

### DIFF
--- a/backend/aris/models/models.py
+++ b/backend/aris/models/models.py
@@ -24,7 +24,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.orm import DeclarativeBase, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 
@@ -304,7 +304,7 @@ class File(Base):
     title = Column(String, nullable=True)
     abstract = Column(Text, nullable=True)
     keywords = Column(String, nullable=True)
-    status: Column[FileStatus] = Column(
+    status: Mapped[FileStatus] = mapped_column(
         Enum(FileStatus, name="filestatus"), nullable=False, default=FileStatus.DRAFT
     )
     last_edited_at = Column(
@@ -318,7 +318,7 @@ class File(Base):
 
     # Publication fields
     published_at = Column(DateTime(timezone=True), nullable=True)
-    public_uuid = Column(String(6), unique=True, nullable=True)
+    public_uuid: Mapped[str | None] = mapped_column(String(6), unique=True, nullable=True)
     permalink_slug = Column(String, unique=True, nullable=True)
     
     # Versioning fields

--- a/backend/aris/models/models.py
+++ b/backend/aris/models/models.py
@@ -357,7 +357,7 @@ class File(Base):
 
     def can_publish(self) -> bool:
         """Check if file can be published."""
-        return bool(self.status == FileStatus.DRAFT and self.source is not None)
+        return bool(self.status == FileStatus.DRAFT and self.source is not None and self.source.strip())
 
     def publish(self) -> None:
         """Publish this file."""

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -5,7 +5,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import current_user, get_db, get_file_service
+from ..crud.utils import assign_public_uuid_with_retry_async
+from ..exceptions import bad_request_exception, forbidden_exception, not_found_exception
 from ..models import FileAsset
+from ..models.models import File as DbFile
+from ..models.models import FileStatus
 from ..services.file_service import FileCreateData, FileUpdateData, InMemoryFileService
 from .file_assets import FileAssetOut
 
@@ -65,6 +69,40 @@ class FileUpdate(BaseModel):
         if self.source:
             _validate_source(self)
         return self
+
+
+class FileStatusUpdate(BaseModel):
+    status: str
+
+    def validate_status(self):
+        valid_statuses = {"draft", "under_review", "published", "withdrawn"}
+        if self.status.lower() not in valid_statuses:
+            raise ValueError(f"Invalid status. Must be one of: {valid_statuses}")
+        return self
+
+
+class PublicationInfoResponse(BaseModel):
+    id: int
+    status: str
+    is_published: bool
+    can_publish: bool
+    published_at: str | None
+    public_uuid: str | None
+    permalink_slug: str | None
+    version: int
+    can_withdraw: bool
+
+    model_config = {"from_attributes": True}
+
+
+class PublicationResponse(BaseModel):
+    id: int
+    status: str
+    published_at: str | None
+    public_uuid: str | None
+    message: str
+
+    model_config = {"from_attributes": True}
 
 
 @router.get("")
@@ -524,3 +562,374 @@ async def get_assets_for_file(
     )
     assets = result.scalars().all()
     return assets
+
+
+@router.post("/{file_id}/publish", response_model=PublicationResponse)
+async def publish_file(
+    file_id: int,
+    user=Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+    file_service: InMemoryFileService = Depends(get_file_service),
+):
+    """Publish a file as a public preprint.
+
+    Parameters
+    ----------
+    file_id : int
+        The unique identifier of the file to publish.
+    user : User
+        Current authenticated user dependency.
+    db : AsyncSession
+        SQLAlchemy async database session dependency.
+    file_service : InMemoryFileService
+        File service dependency.
+
+    Returns
+    -------
+    PublicationResponse
+        Publication confirmation with status and UUID.
+
+    Raises
+    ------
+    HTTPException
+        404 error if file is not found.
+        403 error if user doesn't own the file.
+        400 error if file cannot be published.
+
+    Notes
+    -----
+    Requires authentication. Publication is permanent - once published,
+    a file cannot be unpublished, only withdrawn.
+    """
+    # Sync from database to ensure we have latest data
+    await file_service.sync_from_database(db)
+    
+    # Get file from database to ensure we have the latest version
+    result = await db.execute(
+        select(DbFile).where(
+            DbFile.id == file_id,
+            DbFile.deleted_at.is_(None)
+        )
+    )
+    file = result.scalars().first()
+    
+    if not file:
+        raise not_found_exception("File", file_id)
+    
+    # Check ownership
+    if file.owner_id != user.id:
+        raise forbidden_exception("You do not have permission to publish this file")
+    
+    # Check if file can be published
+    if not file.can_publish():
+        if file.status == FileStatus.PUBLISHED:
+            raise bad_request_exception("File is already published")
+        elif file.status == FileStatus.UNDER_REVIEW:
+            raise bad_request_exception("File is under review and cannot be published")
+        elif file.source is None or not file.source.strip():
+            raise bad_request_exception("File cannot be published without source content")
+        else:
+            raise bad_request_exception("File cannot be published in its current state")
+    
+    # Generate UUID with collision detection if needed
+    if not file.public_uuid:
+        try:
+            file.public_uuid = await assign_public_uuid_with_retry_async(db, file)
+        except RuntimeError as e:
+            raise bad_request_exception(f"Failed to generate public UUID: {str(e)}")
+    
+    # Publish the file
+    file.publish()
+    
+    # Save to database
+    await db.commit()
+    
+    # Update file service cache
+    await file_service.sync_from_database(db)
+    
+    return PublicationResponse(
+        id=file.id,
+        status=file.status.value,
+        published_at=file.published_at.isoformat() if file.published_at else None,
+        public_uuid=file.public_uuid,
+        message="File published successfully"
+    )
+
+
+@router.put("/{file_id}/status", response_model=PublicationResponse)
+async def update_file_status(
+    file_id: int,
+    status_data: FileStatusUpdate,
+    user=Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+    file_service: InMemoryFileService = Depends(get_file_service),
+):
+    """Update a file's publication status.
+
+    Parameters
+    ----------
+    file_id : int
+        The unique identifier of the file to update.
+    status_data : FileStatusUpdate
+        The new status data.
+    user : User
+        Current authenticated user dependency.
+    db : AsyncSession
+        SQLAlchemy async database session dependency.
+    file_service : InMemoryFileService
+        File service dependency.
+
+    Returns
+    -------
+    PublicationResponse
+        Updated publication status information.
+
+    Raises
+    ------
+    HTTPException
+        404 error if file is not found.
+        403 error if user doesn't own the file.
+        400 error if status transition is invalid.
+
+    Notes
+    -----
+    Requires authentication. Some status transitions are restricted:
+    - Published files cannot be unpublished, only withdrawn
+    - Withdrawn files cannot be changed to other statuses
+    """
+    # Validate status
+    try:
+        status_data.validate_status()
+    except ValueError as e:
+        raise bad_request_exception(str(e))
+    
+    # Sync from database to ensure we have latest data
+    await file_service.sync_from_database(db)
+    
+    # Get file from database
+    result = await db.execute(
+        select(DbFile).where(
+            DbFile.id == file_id,
+            DbFile.deleted_at.is_(None)
+        )
+    )
+    file = result.scalars().first()
+    
+    if not file:
+        raise not_found_exception("File", file_id)
+    
+    # Check ownership
+    if file.owner_id != user.id:
+        raise forbidden_exception("You do not have permission to update this file's status")
+    
+    # Map string status to enum
+    status_mapping = {
+        "draft": FileStatus.DRAFT,
+        "under_review": FileStatus.UNDER_REVIEW,
+        "published": FileStatus.PUBLISHED,
+        "withdrawn": FileStatus.PUBLISHED  # Withdrawn is handled by a separate field in the future
+    }
+    
+    new_status = status_mapping[status_data.status.lower()]
+    
+    # Check for invalid transitions
+    if file.status == FileStatus.PUBLISHED and new_status != FileStatus.PUBLISHED:
+        if status_data.status.lower() == "withdrawn":
+            # For now, we'll implement withdrawal as a separate endpoint
+            raise bad_request_exception("Use the withdrawal endpoint to withdraw a published file")
+        else:
+            raise bad_request_exception("Published files cannot be unpublished")
+    
+    # Handle publication
+    if new_status == FileStatus.PUBLISHED:
+        if not file.can_publish():
+            if file.source is None or not file.source.strip():
+                raise bad_request_exception("File cannot be published without source content")
+            else:
+                raise bad_request_exception("File cannot be published in its current state")
+        
+        # Generate UUID with collision detection if needed
+        if not file.public_uuid:
+            try:
+                file.public_uuid = await assign_public_uuid_with_retry_async(db, file)
+            except RuntimeError as e:
+                raise bad_request_exception(f"Failed to generate public UUID: {str(e)}")
+        
+        # Use the publish method to ensure proper timestamp setting
+        file.publish()
+    else:
+        # Update status directly for non-publication status changes
+        file.status = new_status
+    
+    # Save to database
+    await db.commit()
+    
+    # Update file service cache
+    await file_service.sync_from_database(db)
+    
+    return PublicationResponse(
+        id=file.id,
+        status=file.status.value,
+        published_at=file.published_at.isoformat() if file.published_at else None,
+        public_uuid=file.public_uuid,
+        message=f"File status updated to {file.status.value}"
+    )
+
+
+@router.get("/{file_id}/publication-info", response_model=PublicationInfoResponse)
+async def get_publication_info(
+    file_id: int,
+    user=Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+    file_service: InMemoryFileService = Depends(get_file_service),
+):
+    """Get publication information for a file.
+
+    Parameters
+    ----------
+    file_id : int
+        The unique identifier of the file.
+    user : User
+        Current authenticated user dependency.
+    db : AsyncSession
+        SQLAlchemy async database session dependency.
+    file_service : InMemoryFileService
+        File service dependency.
+
+    Returns
+    -------
+    PublicationInfoResponse
+        Publication information including status and capabilities.
+
+    Raises
+    ------
+    HTTPException
+        404 error if file is not found.
+        403 error if user doesn't own the file.
+
+    Notes
+    -----
+    Requires authentication. Returns comprehensive publication status
+    information including what actions are available.
+    """
+    # Sync from database to ensure we have latest data
+    await file_service.sync_from_database(db)
+    
+    # Get file from database
+    result = await db.execute(
+        select(DbFile).where(
+            DbFile.id == file_id,
+            DbFile.deleted_at.is_(None)
+        )
+    )
+    file = result.scalars().first()
+    
+    if not file:
+        raise not_found_exception("File", file_id)
+    
+    # Check ownership
+    if file.owner_id != user.id:
+        raise forbidden_exception("You do not have permission to view this file's publication info")
+    
+    # Calculate can_withdraw (published files can be withdrawn)
+    can_withdraw = file.status == FileStatus.PUBLISHED
+    
+    return PublicationInfoResponse(
+        id=file.id,
+        status=file.status.value,
+        is_published=file.is_published,
+        can_publish=file.can_publish(),
+        published_at=file.published_at.isoformat() if file.published_at else None,
+        public_uuid=file.public_uuid,
+        permalink_slug=file.permalink_slug,
+        version=file.version,
+        can_withdraw=can_withdraw
+    )
+
+
+@router.post("/{file_id}/withdraw", response_model=PublicationResponse)
+async def withdraw_file(
+    file_id: int,
+    user=Depends(current_user),
+    db: AsyncSession = Depends(get_db),
+    file_service: InMemoryFileService = Depends(get_file_service),
+):
+    """Withdraw a published file following arXiv model.
+
+    Parameters
+    ----------
+    file_id : int
+        The unique identifier of the file to withdraw.
+    user : User
+        Current authenticated user dependency.
+    db : AsyncSession
+        SQLAlchemy async database session dependency.
+    file_service : InMemoryFileService
+        File service dependency.
+
+    Returns
+    -------
+    PublicationResponse
+        Withdrawal confirmation with updated status.
+
+    Raises
+    ------
+    HTTPException
+        404 error if file is not found.
+        403 error if user doesn't own the file.
+        400 error if file is not published.
+
+    Notes
+    -----
+    Requires authentication. Following arXiv model, withdrawal maintains
+    the public record but marks the content as withdrawn. The UUID and
+    published timestamp remain unchanged.
+    """
+    # Sync from database to ensure we have latest data
+    await file_service.sync_from_database(db)
+    
+    # Get file from database
+    result = await db.execute(
+        select(DbFile).where(
+            DbFile.id == file_id,
+            DbFile.deleted_at.is_(None)
+        )
+    )
+    file = result.scalars().first()
+    
+    if not file:
+        raise not_found_exception("File", file_id)
+    
+    # Check ownership
+    if file.owner_id != user.id:
+        raise forbidden_exception("You do not have permission to withdraw this file")
+    
+    # Check if file is published
+    if file.status != FileStatus.PUBLISHED:
+        raise bad_request_exception("Only published files can be withdrawn")
+    
+    # Note: In a full implementation, we might add a 'withdrawn_at' timestamp
+    # and a separate 'withdrawn' field to maintain the publication record
+    # but mark it as withdrawn. For now, we'll use a placeholder approach.
+    
+    # For this implementation, we'll keep the file published but add a note
+    # that it's withdrawn. In a future iteration, we might add a separate
+    # withdrawn status or field.
+    
+    # TODO: Implement proper withdrawal following arXiv model
+    # This could include:
+    # - Adding a withdrawn_at timestamp
+    # - Adding a withdrawal reason field
+    # - Keeping the file publicly accessible but with withdrawal notice
+    
+    # For now, return a message indicating withdrawal is not yet fully implemented
+    raise bad_request_exception("Withdrawal functionality is not yet fully implemented. Please contact support.")
+    
+    # Placeholder return (unreachable for now)
+    return PublicationResponse(
+        id=file.id,
+        status=file.status.value,
+        published_at=file.published_at.isoformat() if file.published_at else None,
+        public_uuid=file.public_uuid,
+        message="File withdrawn successfully"
+    )

--- a/backend/aris/routes/file.py
+++ b/backend/aris/routes/file.py
@@ -634,7 +634,8 @@ async def publish_file(
     # Generate UUID with collision detection if needed
     if not file.public_uuid:
         try:
-            file.public_uuid = await assign_public_uuid_with_retry_async(db, file)
+            assigned_uuid: str = await assign_public_uuid_with_retry_async(db, file)
+            file.public_uuid = assigned_uuid
         except RuntimeError as e:
             raise bad_request_exception(f"Failed to generate public UUID: {str(e)}")
     
@@ -730,7 +731,7 @@ async def update_file_status(
         "withdrawn": FileStatus.PUBLISHED  # Withdrawn is handled by a separate field in the future
     }
     
-    new_status = status_mapping[status_data.status.lower()]
+    new_status: FileStatus = status_mapping[status_data.status.lower()]
     
     # Check for invalid transitions
     if file.status == FileStatus.PUBLISHED and new_status != FileStatus.PUBLISHED:
@@ -751,7 +752,8 @@ async def update_file_status(
         # Generate UUID with collision detection if needed
         if not file.public_uuid:
             try:
-                file.public_uuid = await assign_public_uuid_with_retry_async(db, file)
+                assigned_uuid: str = await assign_public_uuid_with_retry_async(db, file)
+                file.public_uuid = assigned_uuid
             except RuntimeError as e:
                 raise bad_request_exception(f"Failed to generate public UUID: {str(e)}")
         


### PR DESCRIPTION
## Summary
Implements comprehensive publication status API endpoints for GitHub issue #106, enabling backend API management of file publication workflow with permanent commitment and UUID integration.

## Key Features
- **POST /files/{file_id}/publish** - Publish files as public preprints with UUID generation
- **PUT /files/{file_id}/status** - Update file publication status with validation
- **GET /files/{file_id}/publication-info** - Query publication information and capabilities
- **POST /files/{file_id}/withdraw** - Withdraw published files (placeholder implementation)

## Technical Implementation
- Integrates with robust UUID generation system from issue #105
- Enforces permanent publication commitment (published files cannot be unpublished)
- Comprehensive error handling with standardized exceptions
- Full authentication and ownership validation
- Proper database transaction handling and file service synchronization

## Testing Coverage
- **17 new unit tests** covering all publication endpoints and error scenarios
- **12 existing integration tests** verify database-level publication workflows
- **All tests pass** including regression tests for existing functionality
- Fixed `File.can_publish()` method to properly handle empty source content

## API Endpoints Added
1. **Publication Toggle**: `POST /files/{file_id}/publish`
   - Publishes draft files to public preprints
   - Generates UUID with collision detection
   - Permanent commitment - cannot be undone

2. **Status Management**: `PUT /files/{file_id}/status`
   - Updates publication status (draft, under_review, published)
   - Enforces valid status transitions
   - Handles UUID generation during publication

3. **Publication Info**: `GET /files/{file_id}/publication-info`
   - Returns comprehensive publication status
   - Includes capabilities (can_publish, can_withdraw)
   - Provides timestamps and UUID information

4. **Withdrawal Placeholder**: `POST /files/{file_id}/withdraw`
   - Following arXiv model for future implementation
   - Currently returns "not fully implemented" message

## Code Quality
- Follows existing codebase patterns and conventions
- Uses standardized error handling with proper HTTP status codes
- Comprehensive docstrings and type hints
- Proper import organization (fixed by ruff linter)

## Test Plan
- All unit tests pass (36/36 in file routes)
- All integration tests pass (12/12 in publication status)
- All UUID utility tests pass (18/18)
- All public access tests pass (16/16)
- No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)